### PR TITLE
Add values files to storage to allow upgrade without specifying them

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ To upgrade the example application, modify the values.yaml or override.yaml file
 ```bash
 composer upgrade -i example -v resources/example_app/values.yaml -v resources/example_app/override.yaml resources/example_app
 ```
+You can also do the following if you want to reuse the same values files (i.e. you don't have to specify them again unless you want to overwrite them):
+```bash
+composer upgrade -i example resources/example_app
+```
 You can then grab the logs of the container to see the overriden variable:
 ```bash
 > docker logs example_container

--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ services:
         target: /usr/share/nginx/html/config/config.json
 ```
 In this example a templated config file is mounted in as `.json` so that its picked up correctly post-templating. This can be very powerful when switching between environments.
+### Debugging issues
+For Vecs not showing up during debugging as per:
+The temporary workaround is:
+```bash
+rustup install nightly-2024-08-01
+rustup override set nightly-2024-08-01
+```
 ## Contributing
 Contributions are welcome! Please submit a pull request or create an issue to discuss any changes.
 

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1,10 +1,10 @@
 use crate::commands::install::add_application;
 use crate::utils::copy_file_utils::get_composer_directory;
+use crate::utils::storage::read_from::get_application_by_id;
 use anyhow::anyhow;
 use clap::Args;
 use std::fs::remove_dir_all;
 use std::path::PathBuf;
-use crate::utils::storage::read_from::get_application_by_id;
 
 #[derive(Debug, Args)]
 pub struct Upgrade {
@@ -19,14 +19,28 @@ pub struct Upgrade {
 impl Upgrade {
     pub fn exec(&self) -> anyhow::Result<()> {
         trace!("Command: {:?}", self);
-        let install_id: &String = &self.id.as_ref().expect("Could not get ID to upgrade.");
+
+        let install_id = match &self.id {
+            Some(id) => id,
+            None => {
+                return Err(anyhow!("Could not get ID to upgrade."));
+            }
+        };
+
         // Ensure the .composer directory exists
         let composer_directory = get_composer_directory()?;
         let composer_id_directory: PathBuf = composer_directory.join(install_id);
-        trace!("Creating directory: '{}'", composer_id_directory.display());
+        trace!(
+            "Checking existence of directory: '{}'",
+            composer_id_directory.display()
+        );
         if !composer_id_directory.exists() {
-            return Err(anyhow!(format!("An application with the id '{}' does not exist. Did you mean to `composer install {}` instead?", install_id, install_id)));
+            return Err(anyhow!(format!(
+                "An application with the id '{}' does not exist. Did you mean to `composer install {}` instead?",
+                install_id, install_id
+            )));
         }
+
         // Determine the value files to use
         let value_files = if self.value_files.is_empty() {
             // Retrieve the persisted application
@@ -55,6 +69,218 @@ impl Upgrade {
             &self.directory,
         )?;
 
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::storage::models::{ApplicationState, PersistedApplication};
+    use crate::utils::storage::read_from::get_application_by_id;
+    use crate::utils::storage::write_to_storage::append_to_storage;
+    use crate::utils::test_utils::clean_up_test_folder;
+    use relative_path::RelativePath;
+    use serial_test::serial;
+    use std::env::current_dir;
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    #[serial]
+    fn test_upgrade_without_id() -> anyhow::Result<()> {
+        // Test that trying to upgrade without an ID results in an error
+        trace!("Running test_upgrade_without_id.");
+        let upgrade_cmd = Upgrade {
+            directory: PathBuf::from("some/directory"),
+            id: None,
+            value_files: vec![],
+        };
+        let err = upgrade_cmd.exec().unwrap_err();
+        let actual_err = err.to_string();
+        let expected_err = "Could not get ID to upgrade.";
+        assert_eq!(expected_err, actual_err);
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_upgrade_nonexistent_application() -> anyhow::Result<()> {
+        // Test that trying to upgrade a nonexistent application results in an error
+        trace!("Running test_upgrade_nonexistent_application.");
+        let id = "nonexistent_app";
+        let current_dir = current_dir()?;
+        let upgrade_dir = RelativePath::new("resources/test/simple/")
+            .to_logical_path(&current_dir);
+        let upgrade_cmd = Upgrade {
+            directory: upgrade_dir,
+            id: Some(id.to_string()),
+            value_files: vec![],
+        };
+        let err = upgrade_cmd.exec().unwrap_err();
+        let actual_err = err.to_string();
+        let expected_err = format!(
+            "An application with the id '{}' does not exist. Did you mean to `composer install {}` instead?",
+            id, id
+        );
+        assert_eq!(expected_err, actual_err);
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_upgrade_no_value_files_provided_and_none_stored() -> anyhow::Result<()> {
+        // Test that upgrading without value files when none were previously stored results in an error
+        trace!("Running test_upgrade_no_value_files_provided_and_none_stored.");
+        let id = "test_upgrade_no_values";
+        let current_dir = current_dir()?;
+        let install_dir =
+            RelativePath::new("resources/test/simple/").to_logical_path(&current_dir);
+
+        // Simulate that the application exists without stored value files
+        // Create the application directory
+        let composer_directory = get_composer_directory()?;
+        let composer_id_directory: PathBuf = composer_directory.join(id);
+        if !composer_id_directory.exists() {
+            fs::create_dir_all(&composer_id_directory)?;
+        }
+
+        // Create a persisted application with empty value_files
+        let app = PersistedApplication {
+            id: id.to_string(),
+            version: "1.0.0".to_string(),
+            timestamp: 0,
+            state: ApplicationState::RUNNING,
+            app_name: "Test App".to_string(),
+            compose_path: install_dir.to_string_lossy().to_string(),
+            value_files: vec![], // Empty value_files
+        };
+        append_to_storage(&app)?;
+
+        // Now, try to upgrade
+        let upgrade_cmd = Upgrade {
+            directory: install_dir.clone(),
+            id: Some(id.to_string()),
+            value_files: vec![],
+        };
+
+        let err = upgrade_cmd.exec().unwrap_err();
+        let actual_err = err.to_string();
+        let expected_err = format!(
+            "Cannot upgrade application '{}' because no value files were provided and none were found from the previous installation. Use -v <values path> to specify value files.",
+            id
+        );
+        // Clean up before assertions in case they fail
+        clean_up_test_folder(id)?;
+        assert_eq!(expected_err, actual_err);
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_upgrade_with_provided_value_files() -> anyhow::Result<()> {
+        // Test that upgrading with provided value files succeeds
+        trace!("Running test_upgrade_with_provided_value_files.");
+        let id = "test_upgrade_with_provided_values";
+        let current_dir = current_dir()?;
+        let install_dir =
+            RelativePath::new("resources/test/simple/").to_logical_path(&current_dir);
+        let values_dir = RelativePath::new("resources/test/test_values/values.yaml")
+            .to_logical_path(&current_dir);
+        let values_str = values_dir.to_string_lossy().to_string();
+
+        // Simulate that the application exists with initial value_files
+        // Create the application directory
+        let composer_directory = get_composer_directory()?;
+        let composer_id_directory = composer_directory.join(id);
+        if !composer_id_directory.exists() {
+            fs::create_dir_all(&composer_id_directory)?;
+        }
+
+        // Create a persisted application with initial value_files
+        let app = PersistedApplication {
+            id: id.to_string(),
+            version: "1.0.0".to_string(),
+            timestamp: 0,
+            state: ApplicationState::RUNNING,
+            app_name: "Test App".to_string(),
+            compose_path: install_dir.to_string_lossy().to_string(),
+            value_files: vec![values_str.clone()],
+        };
+        append_to_storage(&app)?;
+
+        // Now, upgrade with new values
+        let new_values_dir = RelativePath::new("resources/test/test_values/override.yaml")
+            .to_logical_path(&current_dir);
+        let new_values_str = new_values_dir.to_string_lossy().to_string();
+
+        let upgrade_cmd = Upgrade {
+            directory: install_dir.clone(),
+            id: Some(id.to_string()),
+            value_files: vec![new_values_str.clone()],
+        };
+
+        upgrade_cmd.exec()?;
+
+        // Retrieve the application and check that its value_files have been updated
+        let app = get_application_by_id(id)?;
+        // Clean up before assertions in case they fail
+        clean_up_test_folder(id)?;
+
+        assert_eq!(app.value_files, vec![new_values_str]);
+        assert_eq!(app.state, ApplicationState::RUNNING);
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_upgrade_with_no_value_files_but_stored_values_exist() -> anyhow::Result<()> {
+        // Test that upgrading without providing value files uses the stored value files
+        trace!("Running test_upgrade_with_no_value_files_but_stored_values_exist.");
+        let id = "test_upgrade_with_stored_values";
+        let current_dir = current_dir()?;
+        let install_dir =
+            RelativePath::new("resources/test/simple/").to_logical_path(&current_dir);
+        let values_dir = RelativePath::new("resources/test/test_values/values.yaml")
+            .to_logical_path(&current_dir);
+        let values_str = values_dir.to_string_lossy().to_string();
+
+        // Simulate that the application exists with stored value files
+        // Create the application directory
+        let composer_directory = get_composer_directory()?;
+        let composer_id_directory = composer_directory.join(id);
+        if !composer_id_directory.exists() {
+            fs::create_dir_all(&composer_id_directory)?;
+        }
+
+        // Create a persisted application with initial value_files
+        let app = PersistedApplication {
+            id: id.to_string(),
+            version: "1.0.0".to_string(),
+            timestamp: 0,
+            state: ApplicationState::RUNNING,
+            app_name: "Test App".to_string(),
+            compose_path: install_dir.to_string_lossy().to_string(),
+            value_files: vec![values_str.clone()],
+        };
+        append_to_storage(&app)?;
+
+        // Now, upgrade without providing value files
+        let upgrade_cmd = Upgrade {
+            directory: install_dir.clone(),
+            id: Some(id.to_string()),
+            value_files: vec![],
+        };
+
+        upgrade_cmd.exec()?;
+
+        // Retrieve the application and check that its value_files have not changed
+        let app = get_application_by_id(id)?;
+        // Clean up before assertions in case they fail
+        clean_up_test_folder(id)?;
+
+        assert_eq!(app.value_files, vec![values_str]);
+        assert_eq!(app.state, ApplicationState::RUNNING);
         Ok(())
     }
 }

--- a/src/utils/load_values.rs
+++ b/src/utils/load_values.rs
@@ -312,12 +312,6 @@ mod tests {
     }
 
     #[derive(Debug, Serialize, Deserialize)]
-    struct ExpectedYamlSimple {
-        world: String,
-        foo: HashMap<String, String>,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
     struct ExpectedYamlOverride {
         world: String,
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,6 @@ pub mod docker_compose;
 pub mod load_values;
 pub mod storage;
 pub mod template;
-mod test_utils;
+pub mod test_utils;
 pub(crate) mod walk;
 mod yaml_string_parser;

--- a/src/utils/storage/models.rs
+++ b/src/utils/storage/models.rs
@@ -8,6 +8,8 @@ pub struct PersistedApplication {
     pub state: ApplicationState,
     pub app_name: String,
     pub compose_path: String,
+    #[serde(default)]
+    pub value_files: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/src/utils/storage/read_from.rs
+++ b/src/utils/storage/read_from.rs
@@ -77,6 +77,7 @@ mod tests {
             state: ApplicationState::STARTING,
             app_name: id.to_string(),
             compose_path: id.to_string(),
+            value_files: vec!["abc".to_string()],
         };
         let id2 = "test_get_all_from_storage_sunny_day_2";
         let app2 = PersistedApplication {
@@ -86,6 +87,7 @@ mod tests {
             state: ApplicationState::STARTING,
             app_name: id.to_string(),
             compose_path: id.to_string(),
+            value_files: vec![],
         };
         // Append both apps to storage
         append_to_storage(&app)?;
@@ -132,6 +134,7 @@ mod tests {
             state: ApplicationState::STARTING,
             app_name: id.to_string(),
             compose_path: id.to_string(),
+            value_files: vec!["abc".to_string(), "def".to_string()],
         };
         let id2 = "not_looked_for";
         let app2 = PersistedApplication {
@@ -141,6 +144,7 @@ mod tests {
             state: ApplicationState::STARTING,
             app_name: id.to_string(),
             compose_path: id.to_string(),
+            value_files: vec![],
         };
         // Append both apps to storage
         append_to_storage(&app)?;
@@ -168,6 +172,7 @@ mod tests {
             state: ApplicationState::STARTING,
             app_name: id.to_string(),
             compose_path: id.to_string(),
+            value_files: vec![],
         };
         // Append both apps to storage
         append_to_storage(&app)?;

--- a/src/utils/storage/write_to_storage.rs
+++ b/src/utils/storage/write_to_storage.rs
@@ -34,7 +34,7 @@ pub fn append_to_storage(application: &PersistedApplication) -> anyhow::Result<(
         Vec::new()
     } else {
         serde_json::from_str(&contents).with_context(|| {
-            format!("Could not parse ~/.composer/config.json. Is it valid json?")
+            "Could not parse ~/.composer/config.json. Is it valid json?".to_string()
         })?
     };
 

--- a/src/utils/storage/write_to_storage.rs
+++ b/src/utils/storage/write_to_storage.rs
@@ -112,6 +112,7 @@ mod tests {
             state: ApplicationState::STARTING,
             app_name: id.to_string(),
             compose_path: id.to_string(),
+            value_files: vec!["123".to_string(), "abc".to_string()],
         };
         // Append the app to storage
         append_to_storage(&app)?;
@@ -141,6 +142,7 @@ mod tests {
             state: ApplicationState::STARTING,
             app_name: id.to_string(),
             compose_path: id.to_string(),
+            value_files: vec![],
         };
         // Backup config.json
         let (composer_json_config, composer_json_config_backup) = backup_composer_config()?;
@@ -170,6 +172,7 @@ mod tests {
             state: ApplicationState::STARTING,
             app_name: id.to_string(),
             compose_path: id.to_string(),
+            value_files: vec![],
         };
         // Append the app to storage
         append_to_storage(&app)?;

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+use crate::utils::storage::read_from::if_application_exists;
+use crate::utils::storage::write_to_storage::delete_application_by_id;
 
 #[allow(dead_code)]
 pub fn move_file_if_exists(
@@ -41,4 +43,21 @@ pub fn backup_composer_config() -> anyhow::Result<(PathBuf, PathBuf)> {
     let composer_json_config_backup: PathBuf = composer_directory.join("backup-config.json");
     move_file_if_exists(&composer_json_config, &composer_json_config_backup)?;
     Ok((composer_json_config, composer_json_config_backup))
+}
+
+#[allow(dead_code)]
+pub fn clean_up_test_folder(id: &str) -> anyhow::Result<()> {
+    // Clean up folder for test
+    let composer_directory = get_composer_directory()?;
+    let composer_id_directory: PathBuf = composer_directory.join(id);
+    // Remove the composer directory if it exists
+    if composer_id_directory.exists() {
+        fs::remove_dir_all(composer_id_directory)?;
+    }
+    // Remove the persisted application from config.json if it exists
+    if if_application_exists(id) {
+        // This might fail but we tried
+        let _ = delete_application_by_id(id);
+    }
+    Ok(())
 }


### PR DESCRIPTION
This update allows you to upgrade an existing application without re-specifying the values you want to use.